### PR TITLE
fix: Room UI improvements, chat visibility, member analytics & heatmaps

### DIFF
--- a/src/components/dashboard/HabitCard.tsx
+++ b/src/components/dashboard/HabitCard.tsx
@@ -5,6 +5,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useStartSession, useLogHabit, useActiveSessions, useEndSession } from "@/hooks/useHabits";
 import { useState, useEffect } from "react";
 import { calculateProgress, parseTimeString, formatMinutes } from "@/lib/utils";
+import { motion } from "framer-motion";
 
 interface HabitCardProps {
   title: string;
@@ -14,26 +15,11 @@ interface HabitCardProps {
   timeSpentMinutes: number;
   targetTime: number;
   streakCount: number;
-  color: "cyan" | "green" | "orange" | "purple";
+  color: string;
   icon?: React.ReactNode;
   habitId?: string;
   onDelete?: () => void;
 }
-
-const colorMap = {
-  cyan: "progress-cyan",
-  green: "progress-green",
-  orange: "progress-orange",
-  purple: "progress-purple"
-};
-
-const getProgressColor = (progress: number) => {
-  if (progress >= 100) return 'text-chart-green';
-  if (progress >= 80) return 'text-chart-green';
-  if (progress >= 60) return 'text-chart-blue';
-  if (progress >= 40) return 'text-chart-orange';
-  return 'text-chart-red';
-};
 
 export const HabitCard = ({
   title,
@@ -124,13 +110,24 @@ export const HabitCard = ({
 
   return (
     <>
-      <div className="p-5 rounded-lg bg-surface-1 border border-border transition-colors duration-150 hover:bg-surface-2">
+      <motion.div 
+        whileHover={{ scale: 1.015, y: -2 }}
+        transition={{ type: "spring", stiffness: 400, damping: 25 }}
+        className="p-5 rounded-lg bg-surface-1 border border-border transition-colors duration-150 hover:bg-surface-2 hover:shadow-lg"
+        style={{ '--hover-color': `${color}15` } as React.CSSProperties}
+      >
         {/* Header */}
         <div className="flex items-start justify-between mb-4">
           <div className="flex items-center gap-3">
-            <div className={`w-9 h-9 rounded-md bg-${colorMap[color]}/20 flex items-center justify-center`}>
-              {icon || <div className={`w-3.5 h-3.5 rounded-full bg-${colorMap[color]}`} />}
-            </div>
+            <motion.div 
+              whileHover={{ rotate: 10, scale: 1.1 }}
+              className="w-9 h-9 rounded-md flex items-center justify-center" 
+              style={{ backgroundColor: `${color}33` }}
+            >
+              <div style={{ color }}>
+                {icon || <div className="w-3.5 h-3.5 rounded-full" style={{ backgroundColor: color }} />}
+              </div>
+            </motion.div>
             <div>
               <h3 className="font-display font-semibold text-foreground text-[0.95rem] leading-tight">{title}</h3>
               <p className="text-xs text-muted-foreground capitalize mt-0.5">{category}</p>
@@ -165,7 +162,7 @@ export const HabitCard = ({
         <div className="flex items-center justify-between mb-3">
           <CircularProgress progress={currentProgress} color={color} size="lg" />
           <div className="text-right">
-            <div className={`text-2xl font-display font-bold tabular-nums ${getProgressColor(currentProgress)}`}>{timeSpent}</div>
+            <div className="text-2xl font-display font-bold tabular-nums" style={{ color: currentProgress >= 100 ? '#10b981' : color }}>{timeSpent}</div>
             <div className="text-xs text-muted-foreground mt-0.5">spent today</div>
             <div className="text-xs text-muted-foreground mt-1">Target: {formatMinutes(targetTime)}</div>
             {calculateProgress(timeSpentMinutes, targetTime) >= 100 && (
@@ -178,18 +175,18 @@ export const HabitCard = ({
         <div className="mb-4">
           <div className="flex items-center justify-between text-xs text-muted-foreground mb-1">
             <span>0%</span>
-            <span className={`font-medium tabular-nums ${getProgressColor(currentProgress)}`}>
+            <span className="font-medium tabular-nums" style={{ color: currentProgress >= 100 ? '#10b981' : color }}>
               {currentProgress}%
             </span>
             <span>100%</span>
           </div>
           <div className="w-full h-1.5 bg-progress-bg rounded-full overflow-hidden">
-            <div
-              className={`h-full bg-${colorMap[color]} rounded-full transition-all duration-500`}
-              style={{
-                width: `${Math.min(100, currentProgress)}%`,
-                transitionTimingFunction: 'cubic-bezier(0.25, 1, 0.5, 1)'
-              }}
+            <motion.div
+              className="h-full rounded-full"
+              initial={{ width: 0 }}
+              animate={{ width: `${Math.min(100, currentProgress)}%` }}
+              transition={{ duration: 1.5, ease: [0.25, 1, 0.5, 1] }}
+              style={{ backgroundColor: color }}
             />
           </div>
           {isTracking && (
@@ -206,7 +203,7 @@ export const HabitCard = ({
               onClick={handleStopTimer}
               variant="outline"
               size="sm"
-              className="flex-1 h-9 border-destructive/30 text-destructive hover:bg-destructive/10"
+              className="flex-1 h-9 border-destructive/30 text-destructive hover:bg-destructive/10 transition-colors"
             >
               <Square className="w-4 h-4 mr-2" />
               Stop ({Math.floor(trackedTime / 60)}m {trackedTime % 60}s)
@@ -217,7 +214,7 @@ export const HabitCard = ({
               disabled={startSession.isPending}
               variant="outline"
               size="sm"
-              className="flex-1 h-9 border-border hover:bg-surface-2"
+              className="flex-1 h-9 border-border hover:bg-surface-2 hover:border-primary/50 transition-colors"
             >
               {startSession.isPending ? (
                 <Loader2 className="w-4 h-4 mr-2 animate-spin" />
@@ -231,13 +228,13 @@ export const HabitCard = ({
             onClick={handleLogTime}
             variant="outline"
             size="sm"
-            className="px-3 h-9 border-border hover:bg-surface-2"
+            className="px-3 h-9 border-border hover:bg-surface-2 transition-colors"
           >
             <Plus className="w-4 h-4" />
             Log
           </Button>
         </div>
-      </div>
+      </motion.div>
 
       {/* Log Time Modal */}
       {isLogModalOpen && (

--- a/src/components/dashboard/StatsCard.tsx
+++ b/src/components/dashboard/StatsCard.tsx
@@ -10,6 +10,8 @@ interface StatsCardProps {
   className?: string;
 }
 
+import { motion } from "framer-motion";
+
 export const StatsCard = ({
   title,
   value,
@@ -19,13 +21,16 @@ export const StatsCard = ({
   className
 }: StatsCardProps) => {
   return (
-    <div className={cn(
+    <motion.div 
+      whileHover={{ y: -4, scale: 1.02 }}
+      transition={{ type: "spring", stiffness: 300, damping: 20 }}
+      className={cn(
       "p-5 rounded-lg bg-surface-1 border border-border transition-colors duration-150 hover:bg-surface-2",
       className
     )}>
       <div className="flex items-start gap-4">
         <div className={cn(
-          "w-10 h-10 rounded-lg flex items-center justify-center shrink-0",
+          "w-10 h-10 rounded-lg flex items-center justify-center shrink-0 shadow-sm",
           gradient ? "bg-primary" : "bg-surface-2"
         )}>
           <Icon className={cn(
@@ -42,6 +47,6 @@ export const StatsCard = ({
           </div>
         </div>
       </div>
-    </div>
+    </motion.div>
   );
 };

--- a/src/index.css
+++ b/src/index.css
@@ -169,3 +169,32 @@
     animation: none !important;
   }
 }
+
+/* ── Mobile-native overrides (Capacitor) ── */
+@supports (padding: env(safe-area-inset-top)) {
+  .mobile-safe-top { padding-top: env(safe-area-inset-top); }
+  .mobile-safe-bottom { padding-bottom: env(safe-area-inset-bottom); }
+}
+
+/* Smooth momentum scrolling on mobile */
+html {
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Minimum tap targets for mobile */
+@media (max-width: 768px) {
+  button, a, [role="button"] {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+
+/* Hide scrollbar on mobile for cleaner look */
+.hide-scrollbar::-webkit-scrollbar {
+  display: none;
+}
+.hide-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}

--- a/src/pages/RoomDashboard.tsx
+++ b/src/pages/RoomDashboard.tsx
@@ -4,7 +4,7 @@ import { useNavigation } from '@/contexts/NavigationContext';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Activity, ArrowLeft, LogOut, MessageSquare, Send, Users, Plus, Target } from 'lucide-react';
+import { Activity, ArrowLeft, LogOut, MessageSquare, Send, Users, Plus, Target, BarChart3, Calendar } from 'lucide-react';
 import { format } from 'date-fns';
 import { useAuth } from '@/contexts/AuthContext';
 import { useHabits, useDailyStats, useDeleteHabit } from '@/hooks/useHabits';
@@ -12,11 +12,12 @@ import { HabitCard } from '@/components/dashboard/HabitCard';
 import { AddHabitModal } from '@/components/modals/AddHabitModal';
 import { calculateProgress, formatMinutes } from '@/lib/utils';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { iconMap } from '@/pages/Dashboard'; // Import if needed or duplicate
+import { HabitHeatmap } from '@/components/dashboard/HabitHeatmap';
+import { iconMap } from '@/pages/Dashboard';
 
 // Simple icon map fallback
 const localIconMap: Record<string, any> = {
-  code2: <Target className="w-5 h-5" />, // Fallback
+  code2: <Target className="w-5 h-5" />,
 };
 
 const RoomDashboard = () => {
@@ -35,6 +36,7 @@ const RoomDashboard = () => {
   const [chatInput, setChatInput] = useState('');
   const [isAddHabitModalOpen, setIsAddHabitModalOpen] = useState(false);
   const [selectedMember, setSelectedMember] = useState<any | null>(null);
+  const [memberTab, setMemberTab] = useState<'overview' | 'heatmap'>('overview');
 
   // Fetch selected member's personal data
   const { data: memberHabits = [], isLoading: memberHabitsLoading } = useHabits(undefined, selectedMember?.user_id);
@@ -69,49 +71,40 @@ const RoomDashboard = () => {
     );
   }
 
-  // Find current user's role/display name. Assuming we have user from auth, but we can just show the list for now.
-  
   return (
     <div className="max-w-5xl mx-auto space-y-6 animate-fade-up">
-      {/* Header */}
-      <div className="flex items-center justify-between bg-surface-1 p-4 rounded-xl border border-border">
-        <div className="flex items-center gap-4">
-          <Button variant="ghost" size="icon" onClick={handleBack} className="hover:bg-surface-2 text-muted-foreground mr-2">
-            <ArrowLeft className="w-5 h-5" />
-          </Button>
-          <div className="w-12 h-12 rounded-xl bg-surface-2 flex items-center justify-center border border-border">
-            <Users className="w-6 h-6 text-primary" />
-          </div>
-          <div>
-            <h1 className="text-2xl font-display font-bold text-foreground">{room.name}</h1>
-            <div className="flex items-center gap-2 mt-1">
-              <span className="text-xs bg-surface-2 text-muted-foreground px-2 py-0.5 rounded border border-border font-mono">
-                Code: {room.code}
-              </span>
-              <span className="text-sm text-muted-foreground">
-                • {room.members?.length || 0} members
-              </span>
-            </div>
+      {/* Header — no Leave button here */}
+      <div className="flex items-center gap-4 bg-surface-1 p-4 rounded-2xl border border-border">
+        <Button variant="ghost" size="icon" onClick={handleBack} className="hover:bg-surface-2 text-muted-foreground shrink-0">
+          <ArrowLeft className="w-5 h-5" />
+        </Button>
+        <div className="w-12 h-12 rounded-2xl bg-surface-2 flex items-center justify-center border border-border shrink-0">
+          <Users className="w-6 h-6 text-primary" />
+        </div>
+        <div className="min-w-0">
+          <h1 className="text-2xl font-display font-bold text-foreground truncate">{room.name}</h1>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="text-xs bg-surface-2 text-muted-foreground px-2 py-0.5 rounded-lg border border-border font-mono">
+              Code: {room.code}
+            </span>
+            <span className="text-sm text-muted-foreground">
+              • {room.members?.length || 0} members
+            </span>
           </div>
         </div>
-
-        <Button variant="outline" onClick={handleLeave} className="border-border hover:bg-destructive hover:text-destructive-foreground">
-          <LogOut className="w-4 h-4 mr-2" />
-          Leave Room
-        </Button>
       </div>
 
       <Tabs defaultValue="progress" className="w-full">
-        <TabsList className="grid w-full grid-cols-3 bg-surface-1 border border-border p-1 rounded-lg h-auto">
-          <TabsTrigger value="progress" className="py-2.5 data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
+        <TabsList className="grid w-full grid-cols-3 bg-surface-1 border border-border p-1 rounded-2xl h-auto">
+          <TabsTrigger value="progress" className="py-2.5 rounded-xl data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
             <Activity className="w-4 h-4 mr-2" />
             Leaderboard
           </TabsTrigger>
-          <TabsTrigger value="habits" className="py-2.5 data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
+          <TabsTrigger value="habits" className="py-2.5 rounded-xl data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
             <Users className="w-4 h-4 mr-2" />
             Shared Habits
           </TabsTrigger>
-          <TabsTrigger value="chat" className="py-2.5 data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
+          <TabsTrigger value="chat" className="py-2.5 rounded-xl data-[state=active]:bg-surface-2 data-[state=active]:text-foreground">
             <MessageSquare className="w-4 h-4 mr-2" />
             Chat Room
           </TabsTrigger>
@@ -119,18 +112,18 @@ const RoomDashboard = () => {
 
         <TabsContent value="progress" className="mt-6 space-y-6">
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="md:col-span-2 bg-surface-1 p-6 rounded-xl border border-border">
+            <div className="md:col-span-2 bg-surface-1 p-6 rounded-2xl border border-border">
               <h2 className="text-lg font-semibold mb-4 text-foreground flex items-center">
                 Top Members
               </h2>
-              <div className="space-y-4">
-                {[...(room.members || [])] // Create a copy to sort safely
-                  .sort((a, b) => (b.top_streak || 0) - (a.top_streak || 0)) // Sort by highest streak
+              <div className="space-y-3">
+                {[...(room.members || [])]
+                  .sort((a, b) => (b.top_streak || 0) - (a.top_streak || 0))
                   .map((member, i) => (
                   <div 
                     key={member.user_id} 
-                    onClick={() => setSelectedMember(member)}
-                    className="flex flex-col sm:flex-row sm:items-center justify-between p-3 rounded-lg bg-background border border-border hover:border-primary/50 hover:bg-surface-2 transition-colors cursor-pointer group"
+                    onClick={() => { setSelectedMember(member); setMemberTab('overview'); }}
+                    className="flex flex-col sm:flex-row sm:items-center justify-between p-3 rounded-2xl bg-background border border-border hover:border-primary/50 hover:bg-surface-2 transition-colors cursor-pointer group"
                   >
                     <div className="flex items-center gap-3">
                       <div className="w-8 h-8 rounded-full bg-surface-2 group-hover:bg-primary/20 flex items-center justify-center text-xs font-bold font-mono transition-colors">
@@ -138,27 +131,27 @@ const RoomDashboard = () => {
                       </div>
                       <span className="font-medium group-hover:text-primary transition-colors">{member.display_name}</span>
                       {member.role === 'owner' && (
-                        <span className="text-[10px] bg-primary/20 text-primary px-1.5 py-0.5 rounded-sm uppercase tracking-wider font-bold">Host</span>
+                        <span className="text-[10px] bg-primary/20 text-primary px-1.5 py-0.5 rounded-lg uppercase tracking-wider font-bold">Host</span>
                       )}
                     </div>
                     
                     <div className="flex items-center gap-2 mt-2 sm:mt-0 ml-11 sm:ml-0">
-                      <div className="px-2 py-1 rounded bg-orange-500/10 text-orange-400 text-xs font-bold flex items-center border border-orange-500/20">
+                      <div className="px-2 py-1 rounded-lg bg-orange-500/10 text-orange-400 text-xs font-bold flex items-center border border-orange-500/20">
                         🔥 {member.top_streak || 0} day streak
                       </div>
-                      <div className="text-xs text-muted-foreground hidden sm:block">View details</div>
+                      <div className="text-xs text-muted-foreground hidden sm:block">View profile →</div>
                     </div>
                   </div>
                 ))}
               </div>
             </div>
             
-            <div className="bg-surface-1 p-6 rounded-xl border border-border">
+            <div className="bg-surface-1 p-6 rounded-2xl border border-border">
               <h2 className="text-lg font-semibold mb-4 text-foreground">Recent Activity</h2>
               <div className="space-y-3">
                 {recentActivity.length > 0 ? (
                   recentActivity.map((activity, i) => (
-                    <div key={activity.id || i} className="text-sm p-3 bg-background rounded-lg border border-border flex flex-col gap-1">
+                    <div key={activity.id || i} className="text-sm p-3 bg-background rounded-2xl border border-border flex flex-col gap-1">
                       <div className="flex items-center justify-between">
                         <span className="font-medium text-foreground">{activity.display_name}</span>
                         <span className="text-xs text-muted-foreground">{format(new Date(activity.logged_at), 'MMM d, h:mm a')}</span>
@@ -172,7 +165,7 @@ const RoomDashboard = () => {
                     </div>
                   ))
                 ) : (
-                  <div className="text-sm p-4 text-center rounded-lg border border-dashed border-border text-muted-foreground">
+                  <div className="text-sm p-4 text-center rounded-2xl border border-dashed border-border text-muted-foreground">
                     No recent activity yet.
                   </div>
                 )}
@@ -187,20 +180,20 @@ const RoomDashboard = () => {
               <Activity className="w-5 h-5 text-primary" />
               Shared Habits
             </h2>
-            <Button onClick={() => setIsAddHabitModalOpen(true)} className="bg-primary text-primary-foreground hover:opacity-90">
+            <Button onClick={() => setIsAddHabitModalOpen(true)} className="bg-primary text-primary-foreground hover:opacity-90 rounded-2xl">
               <Plus className="w-4 h-4 mr-2" />
               Add Room Habit
             </Button>
           </div>
 
           {habits.length === 0 ? (
-            <div className="bg-surface-1 p-8 rounded-xl border border-border text-center">
+            <div className="bg-surface-1 p-8 rounded-2xl border border-border text-center">
               <Activity className="w-12 h-12 text-muted-foreground mx-auto mb-4" />
               <h3 className="text-lg font-medium text-foreground mb-2">No Shared Habits</h3>
               <p className="text-sm text-muted-foreground mb-6">
                 Create a habit and assign it to this room to track your progress together.
               </p>
-              <Button onClick={() => setIsAddHabitModalOpen(true)} className="bg-primary text-primary-foreground">
+              <Button onClick={() => setIsAddHabitModalOpen(true)} className="bg-primary text-primary-foreground rounded-2xl">
                 <Plus className="w-4 h-4 mr-2" /> Create First Shared Habit
               </Button>
             </div>
@@ -237,8 +230,8 @@ const RoomDashboard = () => {
         </TabsContent>
 
         <TabsContent value="chat" className="mt-6">
-          <div className="bg-surface-1 rounded-xl border border-border flex flex-col h-[600px] overflow-hidden">
-            <div className="bg-surface-2 px-4 py-3 border-b border-border text-xs text-muted-foreground text-center">
+          <div className="bg-surface-1 rounded-2xl border border-border flex flex-col h-[600px] overflow-hidden">
+            <div className="bg-surface-2 px-4 py-3 border-b border-border text-xs text-muted-foreground text-center rounded-t-2xl">
               Messages older than 30 days are automatically deleted to save space. (No images/URLs allowed).
             </div>
             
@@ -262,10 +255,10 @@ const RoomDashboard = () => {
                         </span>
                         {isMe && <span className="text-xs font-bold text-foreground ml-1">You</span>}
                       </div>
-                      <div className={`text-foreground px-3 py-2 rounded-2xl text-sm border max-w-[80%] inline-block ${
+                      <div className={`px-4 py-2.5 rounded-2xl text-sm border max-w-[80%] inline-block ${
                         isMe 
-                          ? 'bg-primary/10 border-primary/20 rounded-tr-sm text-primary-foreground' 
-                          : 'bg-surface-2 border-border rounded-tl-sm'
+                          ? 'bg-surface-3 border-border rounded-tr-sm text-foreground' 
+                          : 'bg-surface-2 border-border rounded-tl-sm text-foreground'
                       }`}>
                         {msg.content}
                       </div>
@@ -275,16 +268,16 @@ const RoomDashboard = () => {
               )}
             </div>
             
-            <div className="p-4 bg-background border-t border-border">
+            <div className="p-4 bg-background border-t border-border rounded-b-2xl">
               <form onSubmit={handleSendChat} className="flex items-center gap-2">
                 <Input 
                   value={chatInput}
                   onChange={e => setChatInput(e.target.value)}
                   placeholder="Type a message... (max 500 chars)"
-                  className="flex-1 bg-surface-1"
+                  className="flex-1 bg-surface-1 rounded-xl"
                   maxLength={500}
                 />
-                <Button type="submit" size="icon" disabled={!chatInput.trim() || sendMessage.isPending}>
+                <Button type="submit" size="icon" className="rounded-xl" disabled={!chatInput.trim() || sendMessage.isPending}>
                   <Send className="w-4 h-4" />
                 </Button>
               </form>
@@ -293,15 +286,23 @@ const RoomDashboard = () => {
         </TabsContent>
       </Tabs>
 
+      {/* Leave Room — at bottom */}
+      <div className="flex justify-center pt-2 pb-8">
+        <Button variant="outline" onClick={handleLeave} className="border-border hover:bg-destructive hover:text-destructive-foreground rounded-2xl px-6">
+          <LogOut className="w-4 h-4 mr-2" />
+          Leave Room
+        </Button>
+      </div>
+
       <AddHabitModal
         isOpen={isAddHabitModalOpen}
         onClose={() => setIsAddHabitModalOpen(false)}
         roomId={currentRoomId}
       />
 
-      {/* Member Profile Modal */}
+      {/* Member Profile Modal — with Analytics & Heatmap */}
       <Dialog open={!!selectedMember} onOpenChange={() => setSelectedMember(null)}>
-        <DialogContent className="sm:max-w-[500px] bg-surface-1 border-border">
+        <DialogContent className="sm:max-w-[600px] max-h-[85vh] overflow-y-auto bg-surface-1 border-border rounded-2xl">
           <DialogHeader>
             <DialogTitle className="flex items-center gap-3 text-xl">
               <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
@@ -310,49 +311,112 @@ const RoomDashboard = () => {
               {selectedMember?.display_name}'s Profile
             </DialogTitle>
           </DialogHeader>
-          <div className="py-6 space-y-6">
-            <div className="grid grid-cols-2 gap-4">
-              <div className="p-4 rounded-xl bg-background border border-border flex flex-col items-center justify-center text-center">
-                <span className="text-3xl font-display font-bold text-orange-400 mb-1">
-                  🔥 {selectedMember?.top_streak || 0}
-                </span>
-                <span className="text-xs text-muted-foreground uppercase font-bold tracking-wider">Top Streak</span>
-              </div>
-              <div className="p-4 rounded-xl bg-background border border-border flex flex-col items-center justify-center text-center">
-                <span className="text-3xl font-display font-bold text-primary mb-1">
-                  {formatMinutes(memberStats?.totalTime || 0)}
-                </span>
-                <span className="text-xs text-muted-foreground uppercase font-bold tracking-wider">Total Time</span>
-              </div>
-            </div>
 
-            <div>
-              <h3 className="text-sm font-semibold mb-3 text-foreground border-b border-border pb-2">Recent Habit Activity</h3>
-              <div className="space-y-2">
+          {/* Tab switcher */}
+          <div className="flex gap-2 mt-2">
+            <button onClick={() => setMemberTab('overview')}
+              className={`px-4 py-2 rounded-xl text-xs font-medium transition-colors ${
+                memberTab === 'overview' ? 'bg-primary text-primary-foreground' : 'bg-surface-2 text-muted-foreground'
+              }`}>
+              <BarChart3 className="w-3.5 h-3.5 inline mr-1.5" />Overview
+            </button>
+            <button onClick={() => setMemberTab('heatmap')}
+              className={`px-4 py-2 rounded-xl text-xs font-medium transition-colors ${
+                memberTab === 'heatmap' ? 'bg-primary text-primary-foreground' : 'bg-surface-2 text-muted-foreground'
+              }`}>
+              <Calendar className="w-3.5 h-3.5 inline mr-1.5" />Activity Heatmap
+            </button>
+          </div>
+
+          <div className="py-4 space-y-6">
+            {memberTab === 'overview' ? (
+              <>
+                {/* Stats */}
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="p-4 rounded-2xl bg-background border border-border flex flex-col items-center justify-center text-center">
+                    <span className="text-2xl font-display font-bold text-orange-400 mb-1">
+                      🔥 {selectedMember?.top_streak || 0}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider">Top Streak</span>
+                  </div>
+                  <div className="p-4 rounded-2xl bg-background border border-border flex flex-col items-center justify-center text-center">
+                    <span className="text-2xl font-display font-bold text-primary mb-1">
+                      {formatMinutes(memberStats?.totalTime || 0)}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider">Today</span>
+                  </div>
+                  <div className="p-4 rounded-2xl bg-background border border-border flex flex-col items-center justify-center text-center">
+                    <span className="text-2xl font-display font-bold text-foreground mb-1">
+                      {memberHabits.length}
+                    </span>
+                    <span className="text-[10px] text-muted-foreground uppercase font-bold tracking-wider">Habits</span>
+                  </div>
+                </div>
+
+                {/* Habit activity list */}
+                <div>
+                  <h3 className="text-sm font-semibold mb-3 text-foreground border-b border-border pb-2">Today's Activity</h3>
+                  <div className="space-y-2">
+                    {memberHabitsLoading ? (
+                      <div className="text-center text-sm text-muted-foreground py-4">Loading habits...</div>
+                    ) : memberHabits.length === 0 ? (
+                      <div className="text-center text-sm text-muted-foreground py-4">No personal habits.</div>
+                    ) : (
+                      memberHabits.slice(0, 8).map((habit: any) => {
+                        const timeSpent = memberStats?.habitTimeSpent?.[habit.id] || 0;
+                        const target = habit.target_duration_minutes || 60;
+                        const pct = Math.min(100, Math.round((timeSpent / target) * 100));
+                        return (
+                          <div key={habit.id} className="p-3 bg-surface-2 rounded-2xl text-sm border border-border">
+                            <div className="flex justify-between items-center mb-1.5">
+                              <span className="flex items-center gap-2 text-foreground font-medium">
+                                <Target className="w-3.5 h-3.5 text-muted-foreground" />
+                                {habit.name}
+                              </span>
+                              <span className="text-xs text-muted-foreground tabular-nums">{timeSpent}m / {target}m</span>
+                            </div>
+                            <div className="w-full h-1.5 bg-background rounded-full overflow-hidden">
+                              <div className="h-full rounded-full transition-all" 
+                                style={{ 
+                                  width: `${pct}%`, 
+                                  backgroundColor: habit.color?.startsWith('#') ? habit.color : 'oklch(var(--primary))'
+                                }} 
+                              />
+                            </div>
+                          </div>
+                        );
+                      })
+                    )}
+                    {!memberHabitsLoading && memberHabits.length > 0 && memberHabits.every((h: any) => (memberStats?.habitTimeSpent?.[h.id] || 0) === 0) && (
+                       <div className="text-center text-sm text-muted-foreground py-4">No logged time today.</div>
+                    )}
+                  </div>
+                </div>
+              </>
+            ) : (
+              /* Heatmap tab — GitHub-style activity heatmaps */
+              <div className="space-y-4">
                 {memberHabitsLoading ? (
-                  <div className="text-center text-sm text-muted-foreground py-4">Loading habits...</div>
+                  <div className="text-center text-sm text-muted-foreground py-8">Loading heatmaps...</div>
                 ) : memberHabits.length === 0 ? (
-                  <div className="text-center text-sm text-muted-foreground py-4">No personal habits.</div>
+                  <div className="text-center text-sm text-muted-foreground py-8">No habits to show heatmaps for.</div>
                 ) : (
-                  memberHabits.slice(0, 5).map((habit: any) => {
-                    const timeSpent = memberStats?.habitTimeSpent?.[habit.id] || 0;
-                    if (timeSpent === 0) return null;
-                    return (
-                      <div key={habit.id} className="p-3 bg-surface-2 rounded-lg text-sm border border-border flex justify-between items-center">
-                        <span className="flex items-center gap-2">
-                          <Target className="w-4 h-4 text-muted-foreground" />
-                          {habit.name}
-                        </span>
-                        <span className="text-green-500 font-bold text-xs uppercase">+{timeSpent} min</span>
+                  memberHabits.slice(0, 6).map((habit: any) => (
+                    <div key={habit.id} className="bg-background rounded-2xl border border-border p-4">
+                      <div className="flex items-center gap-2 mb-2">
+                        <div className="w-3 h-3 rounded-full" style={{ backgroundColor: habit.color?.startsWith('#') ? habit.color : '#10b981' }} />
+                        <span className="text-sm font-medium text-foreground">{habit.name}</span>
                       </div>
-                    );
-                  })
-                )}
-                {!memberHabitsLoading && memberHabits.length > 0 && memberHabits.every((h: any) => (memberStats?.habitTimeSpent?.[h.id] || 0) === 0) && (
-                   <div className="text-center text-sm text-muted-foreground py-4">No logged time today.</div>
+                      <HabitHeatmap 
+                        habitId={habit.id} 
+                        targetTime={habit.target_duration_minutes || 60}
+                        colorTheme={habit.color?.startsWith('#') ? habit.color : undefined}
+                      />
+                    </div>
+                  ))
                 )}
               </div>
-            </div>
+            )}
           </div>
         </DialogContent>
       </Dialog>

--- a/src/services/roomService.ts
+++ b/src/services/roomService.ts
@@ -199,7 +199,7 @@ export const roomService = {
     if (error) throw error;
   },
 
-  // Get recent activity for a room (habit logs for shared habits)
+  // Get recent activity for a room — ALL habit logs from room members (personal + shared)
   async getRecentActivity(roomId: string): Promise<{
     id: string;
     user_id: string;
@@ -209,20 +209,32 @@ export const roomService = {
     logged_at: string;
     is_completed: boolean;
   }[]> {
-    // 1. Get all shared habits in this room
-    const { data: habits, error: habitsError } = await supabase
+    // 1. Get all member user IDs and display names
+    const { data: members, error: membersError } = await supabase
+      .from('room_members')
+      .select('user_id, display_name')
+      .eq('room_id', roomId);
+
+    if (membersError) throw membersError;
+    if (!members || members.length === 0) return [];
+
+    const memberIds = members.map(m => m.user_id);
+    const memberMap = new Map(members.map(m => [m.user_id, m.display_name]));
+
+    // 2. Get ALL habits belonging to any member (personal + shared)
+    const { data: allHabits, error: habitsError } = await supabase
       .from('habits')
-      .select('id, name')
-      .eq('room_id', roomId)
+      .select('id, name, user_id')
+      .in('user_id', memberIds)
       .eq('status', 'active');
 
     if (habitsError) throw habitsError;
-    if (!habits || habits.length === 0) return [];
+    if (!allHabits || allHabits.length === 0) return [];
 
-    const habitIds = habits.map(h => h.id);
-    const habitNameMap = new Map(habits.map(h => [h.id, h.name]));
+    const habitIds = allHabits.map(h => h.id);
+    const habitNameMap = new Map(allHabits.map(h => [h.id, h.name]));
 
-    // 2. Get recent logs for those habits (last 7 days, max 20)
+    // 3. Get recent logs for all those habits (last 7 days, max 30)
     const sevenDaysAgo = new Date();
     sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
@@ -230,21 +242,13 @@ export const roomService = {
       .from('habit_logs')
       .select('id, habit_id, user_id, duration_minutes, logged_at, is_completed')
       .in('habit_id', habitIds)
+      .in('user_id', memberIds)
       .gte('logged_at', sevenDaysAgo.toISOString())
       .order('logged_at', { ascending: false })
-      .limit(20);
+      .limit(30);
 
     if (logsError) throw logsError;
     if (!logs || logs.length === 0) return [];
-
-    // 3. Get display names for members in the room
-    const { data: members, error: membersError } = await supabase
-      .from('room_members')
-      .select('user_id, display_name')
-      .eq('room_id', roomId);
-
-    if (membersError) throw membersError;
-    const memberMap = new Map((members || []).map(m => [m.user_id, m.display_name]));
 
     return logs.map(log => ({
       id: log.id,


### PR DESCRIPTION
- Move Leave Room button to bottom of page
- Round all corners to rounded-2xl for professional look
- Fix chat text visibility (bg-surface-3 / text-foreground for own messages)
- Recent Activity now shows ALL member habits (personal + shared)
- Member profile modal: Overview tab with progress bars + Activity Heatmap tab (GitHub-style)
- Mobile CSS: safe-area insets, smooth scrolling, 44px touch targets